### PR TITLE
Коррекция: Исправление кодстайла в соответствии с правилами линтера

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,186 @@
+# https://bitbucket.app.local/projects/ITD/repos/swift-style-guide/browse/swiftlint.yml
+# https://github.com/realm/SwiftLint
+# список правил, которые необходимо включить (по умолчанию отключены)
+opt_in_rules:
+  - anyobject_protocol
+  - closure_body_length
+  - closure_end_indentation
+  - closure_spacing
+  - collection_alignment
+  - convenience_type
+  - explicit_init
+  - empty_count
+  - fatal_error_message
+  - first_where
+  - force_unwrapping
+  - implicitly_unwrapped_optional
+  - joined_default_parameter
+#!  - lower_acl_than_parent
+  - missing_docs
+  - modifier_order
+  - multiline_arguments
+  - multiline_arguments_brackets
+  - multiline_function_chains
+  - multiline_literal_brackets
+  - multiline_parameters
+  - multiline_parameters_brackets
+  - operator_usage_whitespace
+  - overridden_super_call
+  - private_action
+  - private_outlet
+  - prohibited_super_call
+  - redundant_type_annotation
+  - switch_case_on_newline
+  - trailing_closure
+  - unneeded_parentheses_in_closure_argument
+  - untyped_error_in_catch
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_closing_braces
+
+# !!!путь к исходникам для проверки кода
+#included:
+#  - Project
+
+# подкаталоги, в которых линтер не будет делать проверку кода
+excluded:
+  - Carthage
+  - Pods
+
+# список правил для анализа `swiftlint analyze` (experimental)
+analyzer_rules:
+  - explicit_self
+
+# настройка правил
+cyclomatic_complexity:
+  ignores_case_statements: true
+trailing_closure:
+  only_single_muted_parameter: true
+missing_docs:
+  warning:
+    - public
+    - open
+trailing_semicolon: error
+empty_count:
+  only_after_dot: true
+closing_brace: error
+opening_brace:
+  severity: error
+statement_position:
+  severity: error
+colon:
+  severity: error
+return_arrow_whitespace: error
+comma: error
+vertical_parameter_alignment: error
+vertical_parameter_alignment_on_call: error
+anyobject_protocol: error
+private_outlet:
+  allow_private_set: true
+#! lower_acl_than_parent: error
+operator_usage_whitespace:
+  severity: error
+  skip_aligned_constants: false
+collection_alignment:
+  severity: error
+redundant_type_annotation: error
+multiline_arguments:
+  severity: error
+  first_argument_location: next_line
+  only_enforce_after_first_closure_on_first_line: true
+multiline_arguments_brackets: error
+multiline_parameters_brackets: error
+multiline_literal_brackets: error
+multiline_function_chains: error
+modifier_order:
+  preferred_modifier_order: [acl, setterACL, override, dynamic, mutators, lazy, final, required, convenience, typeMethods, owned]
+
+# кастомные правила
+custom_rules:
+  rus_characters:
+    name: "Russian characters"
+    regex: '([А-я]+)'
+    match_kinds:
+      - identifier
+      - parameter
+    message: "Do not use russian characters in identifiers or parameters"
+    severity: error
+
+  print_using:
+    name: "Print using"
+    regex: '^\s*print\(.*\)'
+    message: "Print decrease performance of the app"
+    severity: warning
+
+  image_name_initialization:
+    name: "Image initialization without SwiftGen"
+    regex: 'UIImage\(named:[^)]+\)'
+    message: "Use SwiftGen UIImageView(image: Asset.someImage.image)"
+    severity: warning
+
+  image_literal_initialization:
+    name: "Image Literal initialization without SwiftGen"
+    regex: '#imageLiteral\(resourceName:[^)]+\)'
+    message: "Use SwiftGen UIImageView(image: Asset.someImage.image)"
+    severity: warning
+
+  color_literal_using:
+    name: "colorLiteral using"
+    regex: '#colorLiteral\(.*\)'
+    message: "Use SwiftGen ColorName.someColor.color"
+    severity: warning
+
+  numbers_smell:
+    name: "Numbers smell"
+    regex: '(case|return)\s-?\d{1,}'
+    message: "Numbers smell. Define a constant instead."
+    severity: warning
+
+# максимально допустимая длина строки
+line_length: 120
+
+# настройка содержимого типа
+type_body_length:
+  warning: 400
+  error: 600
+
+# настройка содержимого файла
+file_length:
+  warning: 500
+  error: 1200
+  ignore_comment_only_lines: true
+
+# настройка названия типа
+type_name:
+  min_length: 3 # only warning
+  max_length: # warning and error
+    warning: 40
+    error: 50
+  excluded: iPhone # excluded via string
+  allowed_symbols: ["_"] # these are allowed in type names
+
+# настройка названия переменной
+identifier_name:
+  min_length: # only min_length
+    error: 2 # only error
+  excluded: # excluded via string array
+    - x
+    - y
+    - z
+    - id
+    # !используется в циклах
+    - i
+
+# настройка уровня вложения
+nesting:
+  type_level: 4
+
+# максимально допустимое кол-во предупреждений
+warning_threshold: 120
+
+# !отключение правил
+disabled_rules:
+# !отключение хвостовых пробелов
+- trailing_whitespace
+
+# тип отчёта по правилам, варианты: (xcode, json, csv, checkstyle, junit, html, emoji, sonarqube, markdown)
+reporter: "xcode"

--- a/ToDoListCleanSwift.xcodeproj/project.pbxproj
+++ b/ToDoListCleanSwift.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 				8563F4A029A4E2C80006C378 /* Sources */,
 				8563F4A129A4E2C80006C378 /* Frameworks */,
 				8563F4A229A4E2C80006C378 /* Resources */,
+				5A411CB129BF3EC500AE3C78 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -277,7 +278,7 @@
 				};
 			};
 			buildConfigurationList = 8563F49F29A4E2C80006C378 /* Build configuration list for PBXProject "ToDoListCleanSwift" */;
-			compatibilityVersion = "Xcode 14.0";
+			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -316,6 +317,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		5A411CB129BF3EC500AE3C78 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n   swiftlint\nelse\n   echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8563F4A029A4E2C80006C378 /* Sources */ = {
@@ -436,7 +457,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -490,7 +511,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/ToDoListCleanSwift/LoginScene/LoginInteractor.swift
+++ b/ToDoListCleanSwift/LoginScene/LoginInteractor.swift
@@ -26,7 +26,8 @@ class LoginInteractor: ILoginInteractor {
 		let response = LoginModels.Response(
 			success: result.success == 1,
 			login: result.login,
-			lastLoginDate: result.lastLoginDate)
+			lastLoginDate: result.lastLoginDate
+		)
 		presenter.present(response: response)
 	}
 }

--- a/ToDoListCleanSwift/LoginScene/LoginViewController.swift
+++ b/ToDoListCleanSwift/LoginScene/LoginViewController.swift
@@ -16,9 +16,9 @@ class LoginViewController: UIViewController {
 	var interactor: ILoginInteractor?
 	private var router: IMainRouter?
 
-	@IBOutlet weak var textFieldLogin: UITextField!
-	@IBOutlet weak var textFieldPassword: UITextField!
-	@IBAction func loginButton(_ sender: UIButton) {
+	@IBOutlet private weak var textFieldLogin: UITextField!
+	@IBOutlet private weak var textFieldPassword: UITextField!
+	@IBAction private func loginButton(_ sender: UIButton) {
 		if let login = textFieldLogin.text, let password = textFieldPassword.text {
 			let request = LoginModels.Request(login: login, password: password)
 			interactor?.login(request: request)

--- a/ToDoListCleanSwift/LoginScene/LoginWorker.swift
+++ b/ToDoListCleanSwift/LoginScene/LoginWorker.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Данные для ответа
 public struct LoginDTO {
 	var success: Int
 	var login: String

--- a/ToDoListCleanSwift/MainRouter.swift
+++ b/ToDoListCleanSwift/MainRouter.swift
@@ -1,9 +1,9 @@
-//////
-//////  MainRouter.swift
-//////  ToDoListCleanSwift
-//////
-//////  Created by Evgeni Meleshin on 21.02.2023.
-//////
+//
+//  MainRouter.swift
+//  ToDoListCleanSwift
+//
+//  Created by Evgeni Meleshin on 21.02.2023.
+//
 
 import Foundation
 

--- a/ToDoListCleanSwift/TasksScene/BL/Task.swift
+++ b/ToDoListCleanSwift/TasksScene/BL/Task.swift
@@ -45,7 +45,7 @@ class ImportantTask: Task {
 	var priority: ImportantTaskPriorities
 	/// Дата выполнения задачи
 	var completionDate: Date {
-		return Calendar.current.date(byAdding: .day, value: priority.dayCountForCompletion, to: Date())!
+		return Calendar.current.date(byAdding: .day, value: priority.dayCountForCompletion, to: Date()) ?? Date()
 	}
 	init(title: String, priority: ImportantTaskPriorities) {
 		self.priority = priority

--- a/ToDoListCleanSwift/TasksScene/BL/TaskManager.swift
+++ b/ToDoListCleanSwift/TasksScene/BL/TaskManager.swift
@@ -8,29 +8,26 @@
 import Foundation
 
 /// Приоритеты важных задач
-enum ImportantTaskPriorities: CustomStringConvertible, CaseIterable {
-	case high
+enum ImportantTaskPriorities: Int, CustomStringConvertible, CaseIterable {
+	case high = 1
 	case medium
 	case low
 
 	var dayCountForCompletion: Int {
-		switch self {
-		case .high: return 1
-		case .medium: return 2
-		case .low: return 3
-		}
+		self.rawValue
 	}
 
 	/// Описание приоритета
 	var description: String {
 		switch self {
-
-		case .high: return "high"
-		case .medium: return "medium"
-		case .low: return "low"
+		case .high:
+			return "high"
+		case .medium:
+			return "medium"
+		case .low:
+			return "low"
 		}
 	}
-
 }
 
 /// Протокол менеджера задач
@@ -54,12 +51,12 @@ final class TaskManager {
 
 	/// Получить выполненные задачи
 	public func completedTasks() -> [Task] {
-		tasksList.filter({ $0.completed == true})
+		tasksList.filter { $0.completed == true }
 	}
 
 	/// Получить навыполненные задачи
 	public func uncompletedTasks() -> [Task] {
-		return tasksList.filter({ $0.completed != true})
+		return tasksList.filter { $0.completed != true }
 	}
 
 	/// Добавить задачу в список
@@ -67,6 +64,8 @@ final class TaskManager {
 		tasksList.append(task)
 	}
 
+	/// Добавить задачи
+	/// - Parameter tasks: массив новых задач
 	public func addTasks(tasks: [Task]) {
 		tasksList.append(contentsOf: tasks)
 	}

--- a/ToDoListCleanSwift/TasksScene/Managers/SectionsAdapter.swift
+++ b/ToDoListCleanSwift/TasksScene/Managers/SectionsAdapter.swift
@@ -24,8 +24,10 @@ enum SectionsTypes: Int, CustomStringConvertible, CaseIterable {
 
 	var description: String {
 		switch self {
-		case .uncompletedTasks: return "Невыполненные задачи"
-		case .completedTasks: return "Выполненные задачи"
+		case .uncompletedTasks:
+			return "Невыполненные задачи"
+		case .completedTasks:
+			return "Выполненные задачи"
 		}
 	}
 }
@@ -57,6 +59,8 @@ final class SectionAdapter: ISectionsAdapter {
 		for sectionType in sectionsTypes {
 			let index = getTasksForSectionsType(sectionType: sectionType).firstIndex { task === $0 }
 			if index != nil {
+				// TODO: - change logic
+				// swiftlint:disable:next force_unwrapping
 				return (sectionType, index!)
 			}
 		}

--- a/ToDoListCleanSwift/TasksScene/Managers/TasksDependenciesBuilder.swift
+++ b/ToDoListCleanSwift/TasksScene/Managers/TasksDependenciesBuilder.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Класс сборщика
-final class TasksDependenciesBuilder {
+enum TasksDependenciesBuilder {
 	static func build() -> TasksViewController {
 
 		let tasksViewController = TasksViewController()
@@ -16,9 +16,10 @@ final class TasksDependenciesBuilder {
 		let taskManager = OrderedTaskManager(taskManager: TaskManager())
 		let repository: IRepository = Repository()
 		let sectionsAdapter = SectionAdapter(taskManager: taskManager)
-		let tasksPresenter: ITasksPresenter = TasksPresenter(view: tasksViewController, sectionsAdapter: sectionsAdapter)
+		let tasksPresenter = TasksPresenter(sectionsAdapter: sectionsAdapter)
 		let tasksInteractor = TasksInteractor()
 
+		tasksPresenter.view = tasksViewController
 		tasksViewController.interactor = tasksInteractor
 		tasksInteractor.presenter = tasksPresenter
 		tasksInteractor.worker = tasksWorker

--- a/ToDoListCleanSwift/TasksScene/TasksModels.swift
+++ b/ToDoListCleanSwift/TasksScene/TasksModels.swift
@@ -33,7 +33,6 @@ enum TaskModel {
 		enum Task {
 			case regularTask(RegularLask)
 			case importantTask(ImportantTask)
-
 		}
 		struct Section {
 			let title: String

--- a/ToDoListCleanSwift/TasksScene/TasksPresenter.swift
+++ b/ToDoListCleanSwift/TasksScene/TasksPresenter.swift
@@ -15,11 +15,10 @@ protocol ITasksPresenter {
 /// Класс презентера
 class TasksPresenter: ITasksPresenter {
 
-	private weak var view: ITasksViewController!
-	private var sectionsAdapter: ISectionsAdapter!
+	weak var view: ITasksViewController?
+	private var sectionsAdapter: ISectionsAdapter
 
-	init(view: ITasksViewController!, sectionsAdapter: ISectionsAdapter!) {
-		self.view = view
+	init(sectionsAdapter: ISectionsAdapter) {
 		self.sectionsAdapter = sectionsAdapter
 	}
 
@@ -28,10 +27,11 @@ class TasksPresenter: ITasksPresenter {
 		for dataItem in response.data {
 			let section = TaskModel.ViewData.Section(
 				title: dataItem.sectionType.description,
-				tasks: createViewDataFromTasks(tasks: dataItem.sectionTasks))
+				tasks: createViewDataFromTasks(tasks: dataItem.sectionTasks)
+			)
 			sectionTypes.append(section)
 		}
-		view.render(viewData: TaskModel.ViewData(tasksBySections: sectionTypes))
+		view?.render(viewData: TaskModel.ViewData(tasksBySections: sectionTypes))
 	}
 
 	private func createViewDataFromTasks(tasks: [Task]) -> [TaskModel.ViewData.Task] {
@@ -45,13 +45,16 @@ class TasksPresenter: ITasksPresenter {
 				completed: task.completed,
 				priority: task.priority.description,
 				completionDate: getStringByDate(date: task.completionDate),
-				overdue: task.completionDate < Date() ? true : false)
+				overdue: task.completionDate < Date() ? true : false
+			)
 			return .importantTask(importantTask)
 		} else {
-			return .regularTask(TaskModel.ViewData.RegularLask(
-				title: task.title,
-				completed: task.completed
-			))
+			return .regularTask(
+				TaskModel.ViewData.RegularLask(
+					title: task.title,
+					completed: task.completed
+				)
+			)
 		}
 	}
 

--- a/ToDoListCleanSwift/TasksScene/TasksViewController.swift
+++ b/ToDoListCleanSwift/TasksScene/TasksViewController.swift
@@ -61,7 +61,7 @@ extension TasksViewController: UITableViewDelegate, UITableViewDataSource {
 
 		switch taskData {
 		case .importantTask(let task):
-			let pinkColor = #colorLiteral(red: 1, green: 0.8035419583, blue: 0.8338577151, alpha: 1)
+			let pinkColor: UIColor = .systemPink
 			cell.backgroundColor = task.overdue ? pinkColor : .white
 			cell.title.text = task.title
 			cell.completionDate.text = task.completionDate

--- a/ToDoListCleanSwift/TasksScene/TasksViewController.swift
+++ b/ToDoListCleanSwift/TasksScene/TasksViewController.swift
@@ -75,7 +75,7 @@ extension TasksViewController: UITableViewDelegate, UITableViewDataSource {
 		}
 
 		cell.completeAction = { [weak self] in
-			guard let self else { return }
+			guard let self = self else { return }
 			self.interactor?.didCheckboxTapped(indexPath: indexPath)
 		}
 		return cell

--- a/ToDoListCleanSwift/TasksScene/TasksWorker.swift
+++ b/ToDoListCleanSwift/TasksScene/TasksWorker.swift
@@ -22,5 +22,4 @@ class TasksWorker: ITasksWorker {
 		}
 		return response
 	}
-
 }

--- a/ToDoListCleanSwiftTests/Managers/TaskManagerTests.swift
+++ b/ToDoListCleanSwiftTests/Managers/TaskManagerTests.swift
@@ -9,27 +9,13 @@ import XCTest
 @testable import ToDoListCleanSwift
 
 final class TaskManagerTests: XCTestCase {
-
-	// MARK: - Private properties
-
-	private var sut: TaskManager!
-
-	// MARK: - Lifecycle
-
-	override func setUp() {
-		super.setUp()
-		sut = TaskManager()
-	}
-
-	override func tearDown() {
-		sut = nil
-		super.tearDown()
-	}
-
 	// MARK: - Tests
 
 	// Проверка того, что менеджер после инициализации имеет пустой список задач
 	func test_taskListIsEmptyAfterInit() {
+		// given
+		let sut = TaskManager()
+		
 		// when
 		let tasks = sut.allTasks()
 
@@ -39,6 +25,7 @@ final class TaskManagerTests: XCTestCase {
 
 	func test_allTasks_shouldBeEqual() {
 		// Given
+		let sut = TaskManager()
 		let tasks = TasksStub.tasks
 
 		// When
@@ -51,6 +38,7 @@ final class TaskManagerTests: XCTestCase {
 
 	func test_completedTasks_shouldBeEqual() {
 		// Given
+		let sut = TaskManager()
 		let tasks = TasksStub.completedTasks
 
 		// When
@@ -64,6 +52,7 @@ final class TaskManagerTests: XCTestCase {
 	func test_uncompletedTasks_shouldBeEqual() {
 		// Given
 		let tasks = TasksStub.uncompletedTasks
+		let sut = TaskManager()
 
 		// When
 		sut.addTasks(tasks: TasksStub.tasks)
@@ -71,11 +60,11 @@ final class TaskManagerTests: XCTestCase {
 
 		// Then
 		XCTAssertEqual(result, tasks)
-
 	}
 
 	func test_addTask_shouldBeEqual() {
 		// Given
+		let sut = TaskManager()
 		var tasks = TasksStub.tasks
 		tasks.append(TasksStub.newTask)
 
@@ -90,6 +79,7 @@ final class TaskManagerTests: XCTestCase {
 
 	func test_addTasks_shouldBeEqual() {
 		// Given
+		let sut = TaskManager()
 		var tasks = [Task]()
 		tasks.append(contentsOf: TasksStub.tasks)
 
@@ -103,6 +93,7 @@ final class TaskManagerTests: XCTestCase {
 
 	func test_removeTask_shouldBeEqual() {
 		// Given
+		let sut = TaskManager()
 		let tasks = TasksStub.tasksListAfterRemove
 
 		// When

--- a/ToDoListCleanSwiftTests/Tasks/ImportantTaskTests.swift
+++ b/ToDoListCleanSwiftTests/Tasks/ImportantTaskTests.swift
@@ -27,7 +27,8 @@ final class ImportantTaskTests: XCTestCase {
 			XCTAssertEqual(
 				differenceDays,
 				priority.dayCountForCompletion,
-				"Difference for \(priority) should be \(priority.dayCountForCompletion)")
+				"Difference for \(priority) should be \(priority.dayCountForCompletion)"
+			)
 		}
 	}
 }

--- a/ToDoListCleanSwiftTests/Tasks/RegularTaskTests.swift
+++ b/ToDoListCleanSwiftTests/Tasks/RegularTaskTests.swift
@@ -26,5 +26,4 @@ final class RegularTaskTests: XCTestCase {
 		// assert
 		XCTAssertNotEqual(startState, endState, "Values should not be equals")
 	}
-
 }


### PR DESCRIPTION
1. Поддержка старых версий Xcode
2. Добавлены правила от Кирилла (пару изменений со знаком !)
3. Из за использования force unwrap пришлось местами править логику:
    - конструктор и сборка TaskPresenter
    - тесты: sut как локальная переменная в каждом тесте
    - ввод значений по умолчанию Date()
4. Избавился от запаха магических чисел через `enum ImportantTaskPriorities: Int`
5. Исправлены другие моменты по правилам